### PR TITLE
Add a local-model provider alongside Gemini (--local)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ at scale, this pattern cut video-workflow AI costs to roughly **1/25th**.
 | **[Spec](#-spec)** | [SPEC.md](SPEC.md) | The normative format definition (v1.0) |
 | **[Engine](#-engine-core-library)** | [cli/cdaf/](cli/cdaf/) | Python library: parse, validate, hash, generate |
 | **[CLI](#-cli)** | [cli/](cli/) | `cdaf` command: generate / validate / read / status |
+| **Local provider** | [cli/cdaf/local.py](cli/cdaf/local.py) | `--local`: generate with a local model, no API key |
 | **[Agent Skill](#-agent-skill)** | [skills/](skills/claude-code/cdaf/SKILL.md) | Teaches agents the sidecar-first protocol · `npx cdaf-skill` |
 | **[Benchmarks](#-benchmarks)** | [benchmarks/](benchmarks/) | Reproducible eval: sidecar vs direct video |
 | **[Paper](#-paper)** | [paper/PREPRINT.md](paper/PREPRINT.md) | arXiv preprint draft built on the benchmark |

--- a/cli/README.md
+++ b/cli/README.md
@@ -3,11 +3,29 @@
 Generate and validate CDAF sidecars — timestamped descriptive text files that let AI
 agents reuse one video-understanding pass instead of re-analyzing footage.
 
+Not on PyPI yet, so install from the repository:
+
 ```bash
-pip install cdaf[generate]      # or plain `pip install cdaf` for validate/read/status only
-export GEMINI_API_KEY=your-key
-cdaf generate ./footage
+pip install "cdaf[generate] @ git+https://github.com/UditAkhourii/cdaf.git#subdirectory=cli"
 ```
+
+Drop the `[generate]` extra for `validate` / `read` / `status` only -- those need no
+dependencies and no key.
+
+Two generation providers:
+
+```bash
+export GEMINI_API_KEY=your-key
+cdaf generate ./footage                  # Gemini Files API; handles directories
+
+cdaf generate ./clip.mp4 --local         # a local OpenAI-compatible endpoint
+```
+
+`--local` needs `ffmpeg` and a served multimodal model instead of a key, and never
+sends the footage anywhere. Point it with `--base-url` / `--model` (or `CDAF_BASE_URL`
+/ `CDAF_LOCAL_MODEL`); set `CDAF_PROVIDER=local` to make it the default. One clip at a
+time, and slower per clip -- but free, private, and priced per shot rather than per
+second of footage. See `cdaf/local.py` for what it does differently.
 
 Commands: `generate`, `validate`, `read`, `status`. Full docs and the format
 specification live in the repository root: see `README.md` and `SPEC.md`.

--- a/cli/cdaf/cli.py
+++ b/cli/cdaf/cli.py
@@ -1,7 +1,7 @@
 """cdaf — command-line tool for CDAF sidecars.
 
 Commands:
-  generate   Create/refresh .cdaf sidecars for video files (needs Gemini key)
+  generate   Create/refresh .cdaf sidecars (Gemini by default, or a local model)
   validate   Verify a sidecar is well-formed and fresh (hash matches video)
   read       Print a sidecar's body (what an agent should consume)
   status     Report fresh/stale/missing across a directory tree
@@ -76,7 +76,9 @@ def cmd_generate(args: argparse.Namespace) -> int:
         print(f"  generating  {video} ...", flush=True)
         try:
             sc = generate_sidecar(
-                video, model=args.model, detail=args.detail, api_key=args.api_key
+                video, model=args.model, detail=args.detail, api_key=args.api_key,
+                provider=args.provider, base_url=args.base_url,
+                scene_threshold=args.scene_threshold
             )
             save(sc, sidecar)
             print(f"  wrote   {sidecar}")
@@ -157,12 +159,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--version", action="version", version=f"cdaf {__version__}")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    g = sub.add_parser("generate", help="create/refresh sidecars for videos (Gemini BYOK)")
+    g = sub.add_parser("generate", help="create/refresh sidecars for videos")
     g.add_argument("paths", nargs="+", help="video files, sidecars, or directories (recursive)")
     g.add_argument("--model", default=None, help="Gemini model id (default: env CDAF_MODEL or gemini-2.5-flash)")
     g.add_argument("--detail", choices=["brief", "standard", "rich"], default="standard")
     g.add_argument("--force", action="store_true", help="regenerate even if sidecar is fresh")
     g.add_argument("--api-key", default=None, help="Gemini API key (default: env GEMINI_API_KEY)")
+    g.add_argument("--provider", choices=["gemini", "local"], default=None,
+                   help="gemini = Files API, needs a key (default); "
+                        "local = OpenAI-compatible endpoint, no key or cost "
+                        "(default: env CDAF_PROVIDER)")
+    g.add_argument("--local", dest="provider", action="store_const", const="local",
+                   help="shorthand for --provider local")
+    g.add_argument("--scene-threshold", type=float, default=None, metavar="F",
+                   help="local: ffmpeg scene-detect sensitivity, 0-1 (default 0.15). "
+                        "Lower finds more cuts, including low-contrast ones, at the "
+                        "cost of splitting on camera movement")
+    g.add_argument("--base-url", default=None,
+                   help="local endpoint (default: env CDAF_BASE_URL or "
+                        "http://127.0.0.1:8090/v1)")
     g.set_defaults(func=cmd_generate)
 
     v = sub.add_parser("validate", help="check one sidecar is well-formed and fresh")
@@ -180,9 +195,18 @@ def main(argv: list[str] | None = None) -> int:
     s.set_defaults(func=cmd_status)
 
     args = parser.parse_args(argv)
-    if getattr(args, "model", None) is None and args.command == "generate":
-        from .generate import DEFAULT_MODEL
-        args.model = DEFAULT_MODEL
+    if args.command == "generate":
+        from .generate import DEFAULT_PROVIDER
+        if getattr(args, "provider", None) is None:
+            args.provider = DEFAULT_PROVIDER
+        if getattr(args, "model", None) is None:
+            # Each provider has its own default model id.
+            if args.provider == "local":
+                from .local import DEFAULT_LOCAL_MODEL
+                args.model = DEFAULT_LOCAL_MODEL
+            else:
+                from .generate import DEFAULT_MODEL
+                args.model = DEFAULT_MODEL
     return args.func(args)
 
 

--- a/cli/cdaf/generate.py
+++ b/cli/cdaf/generate.py
@@ -1,4 +1,7 @@
-"""Generate a CDAF sidecar body from a video using Gemini (BYOK).
+"""Generate a CDAF sidecar body from a video.
+
+Two providers: Gemini (BYOK, default) and a local OpenAI-compatible endpoint
+(see local.py). Select with the `provider` argument or CDAF_PROVIDER.
 
 Requires the `google-genai` package (`pip install cdaf[generate]`) and a
 GEMINI_API_KEY (or GOOGLE_API_KEY) environment variable, or an explicit key.
@@ -16,6 +19,8 @@ from .probe import probe
 from .sidecar import SPEC_VERSION, Sidecar, hash_file
 
 DEFAULT_MODEL = os.environ.get("CDAF_MODEL", "gemini-2.5-flash")
+DEFAULT_PROVIDER = os.environ.get("CDAF_PROVIDER", "gemini")
+PROVIDERS = ("gemini", "local")
 
 _DETAIL_GUIDANCE = {
     "brief": (
@@ -145,9 +150,19 @@ def generate_sidecar(
     model: str = DEFAULT_MODEL,
     detail: str = "standard",
     api_key: str | None = None,
+    provider: str = DEFAULT_PROVIDER,
+    base_url: str | None = None,
+    scene_threshold: float | None = None,
     usage_out: dict | None = None,
 ) -> Sidecar:
-    """Full pipeline: hash + probe + describe → a ready-to-save Sidecar."""
+    """Full pipeline: hash + probe + describe → a ready-to-save Sidecar.
+
+    provider="gemini" uploads the video to the Gemini Files API (needs a key).
+    provider="local" samples frames and posts them to an OpenAI-compatible
+    endpoint (no key, no cost, footage stays on the machine).
+    """
+    if provider not in PROVIDERS:
+        raise ValueError(f"provider must be one of {list(PROVIDERS)}")
     video = Path(video)
     header = {
         "video": video.name,
@@ -159,7 +174,24 @@ def generate_sidecar(
         "detail": detail,
         "lang": "en",
     }
-    body = describe_video(
-        video, model=model, detail=detail, api_key=api_key, usage_out=usage_out
-    )
+
+    if provider == "local":
+        from . import local  # lazy: keeps ffmpeg/endpoint concerns out of the Gemini path
+
+        threshold = (local.DEFAULT_SCENE_THRESHOLD if scene_threshold is None
+                     else scene_threshold)
+        body = local.describe_video_local(
+            video, model=model, detail=detail,
+            base_url=base_url or local.DEFAULT_BASE_URL,
+            scene_threshold=threshold, usage_out=usage_out
+        )
+        header.update(local.local_header_extras(
+            continuity=True, transcribed="(no speech)" not in body,
+            threshold=threshold
+        ))
+    else:
+        body = describe_video(
+            video, model=model, detail=detail, api_key=api_key, usage_out=usage_out
+        )
+
     return Sidecar(version=SPEC_VERSION, header=header, body=body)

--- a/cli/cdaf/local.py
+++ b/cli/cdaf/local.py
@@ -1,0 +1,550 @@
+"""Generate a CDAF body with a local multimodal model (OpenAI-compatible endpoint).
+
+An alternative to the Gemini provider in generate.py. No API key, no per-clip cost,
+and the footage never leaves the machine. Requires ffmpeg and a served model with a
+vision encoder; an audio encoder is used for the transcript when present.
+
+The Files API path (upload whole video, ask once) is not available locally, so this
+provider samples frames itself. That turns out to be an advantage rather than a
+workaround:
+
+  * Segment boundaries come from ffmpeg scene detection, so the boundaries it finds
+    are frame-exact rather than inferred. Recall depends on --scene-threshold: a
+    low-contrast transition can score below it and be missed, merging two shots.
+  * Each shot is described on its own. A describer that cannot see the next shot
+    cannot invent a causal chain across shots.
+  * Transcript timing is measured from a speech-band energy envelope. Models
+    transcribe accurately but are poor at timestamps.
+
+No third-party dependencies: stdlib urllib only.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from .generate import GenerationError
+
+DEFAULT_BASE_URL = os.environ.get("CDAF_BASE_URL", "http://127.0.0.1:8090/v1")
+DEFAULT_LOCAL_MODEL = os.environ.get("CDAF_LOCAL_MODEL", "local")
+HTTP_TIMEOUT = 900
+FRAME_WIDTH = 896
+
+# Frames sampled per shot, and sentences requested, by --detail level.
+_DETAIL_FRAMES = {"brief": 1, "standard": 2, "rich": 3}
+_DETAIL_SENTENCES = {"brief": "one short sentence", "standard": "1-2 sentences",
+                     "rich": "2-4 sentences covering subjects, actions, setting, "
+                             "camera framing and movement, lighting, colour and mood"}
+
+_SHOT_PROMPT = """You are describing ONE shot from a video. You are shown {n} frame(s) \
+sampled from inside this single shot, in order.
+
+Describe what is visible in these frames, in {sentences}.
+
+- Do NOT say a task was completed, fixed, or finished unless the finished result is \
+plainly visible. Someone holding a tool or a detached part is intent, not completion.
+- Do NOT invent motion you cannot see across the given frames, and do not guess at what \
+happened before or after this shot.
+- Name what you can identify. If an object is clearly a screwdriver or a light bulb, say \
+so; fall back on shape and colour only when you genuinely cannot tell.
+- Transcribe visible text EXACTLY as written, including any list numbering. Report only \
+deliberate, legible text: burned-in titles and graphics, signage, screens, handwriting \
+the shot is showing you. Ignore incidental text on background packaging or labels, and \
+never guess a brand from a partly visible logo.
+
+Reply with ONLY a JSON object, no prose or code fences:
+{{"description": "...", "visible_text": ["exact text"], "setting": "short location phrase"}}
+
+Use an empty list for visible_text if there is no legible text."""
+
+_CONTINUITY_PROMPT = """These descriptions of one video's shots were written \
+independently -- each describer saw only its own shot. So the same person and place are \
+reintroduced from scratch every time, and objects are described by shape when the \
+surrounding shots make their identity obvious.
+
+Rewrite the list so it reads as one document about one video.
+
+You MAY: introduce the subject once and then use a pronoun; name a place once and then \
+refer back to it; name an object when neighbouring shots or the on-screen text make its \
+identity unambiguous; label a shot as a POV, insert or close-up when the neighbours make \
+that clear; quote on-screen text where it carries meaning.
+
+You MUST NOT: add any action or event that is not in the input; say a task was completed \
+unless an input says the finished result is visible; add a colour or material that is not \
+in the input for that shot; drop or merge shots. Return exactly {n} descriptions in the \
+same order, {sentences} each.
+
+Then a Summary paragraph: what the clip is, its arc, anything it names or advertises, and \
+what it would be useful for. Then 12-20 retrieval keywords.
+
+Reply with ONLY a JSON object, no prose or code fences:
+{{"segments": ["..."], "summary": "...", "tags": ["keyword"]}}
+
+Shots:
+{shots}
+
+Narration:
+{narration}
+
+On-screen text:
+{screen_text}"""
+
+_ASR_PROMPT = """Transcribe the spoken narration in this audio verbatim.
+
+This audio contains exactly {n} spoken segments, separated by pauses. Output exactly {n} \
+lines, one per segment, in order. No timestamps, no numbering, no blank lines -- just the \
+words. If you hear fewer distinct segments, still split the narration into {n} lines at \
+the most natural pauses."""
+
+# Replies that are the assistant talking rather than transcribing. Asked to transcribe
+# silence, a model answers as a chatbot instead of declining, and that lands in the
+# sidecar looking like narration.
+_NON_TRANSCRIPT = (
+    "large language model", "i am an ai", "as an ai", "i'm an ai", "trained by",
+    "i cannot", "i can't", "i'm unable", "i am unable", "no speech", "no audible",
+    "no discernible", "there is no", "cannot transcribe", "unable to transcribe", "sorry",
+)
+
+
+# --------------------------------------------------------------------- ffmpeg
+
+def _run(cmd: list[str], timeout: int = 300) -> str:
+    return subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=timeout, check=True).stdout
+
+
+def _require_ffmpeg() -> None:
+    for tool in ("ffmpeg", "ffprobe"):
+        if not shutil.which(tool):
+            raise GenerationError(
+                f"{tool} is required by the local provider but was not found on PATH"
+            )
+
+
+def _duration(video: Path) -> float:
+    try:
+        return float(_run(["ffprobe", "-v", "error", "-show_entries",
+                           "format=duration", "-of", "csv=p=0", str(video)]).strip())
+    except (subprocess.SubprocessError, ValueError, OSError) as e:
+        raise GenerationError(f"could not read duration of {video.name}: {e}") from e
+
+
+def detect_cuts(video: Path, threshold: float = 0.15) -> list[float]:
+    """Scene-change timestamps in seconds, ascending."""
+    # metadata=print writes to stdout so it survives `-v error`; showinfo logs at info
+    # level and would be swallowed by the same flag.
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", str(video),
+             "-vf", f"select='gt(scene,{threshold})',metadata=print:file=-",
+             "-f", "null", "-"],
+            capture_output=True, text=True, timeout=900)
+    except (subprocess.SubprocessError, OSError):
+        return []
+    return sorted({round(float(m), 2)
+                   for m in re.findall(r"pts_time:([0-9.]+)", proc.stdout)})
+
+
+def build_shots(duration: float, cuts: list[float],
+                min_len: float = 0.35) -> list[tuple[float, float]]:
+    """Cut points to [start, end) spans, absorbing sub-min_len slivers."""
+    bounds = [0.0] + [c for c in cuts if min_len < c < duration - min_len] + [duration]
+    shots: list[tuple[float, float]] = []
+    for a, b in zip(bounds, bounds[1:]):
+        if b - a >= min_len:
+            shots.append((a, b))
+        elif shots:
+            shots[-1] = (shots[-1][0], b)
+    return shots or [(0.0, duration)]
+
+
+def coarsen(shots: list[tuple[float, float]],
+            target: float = 8.0) -> list[tuple[float, float]]:
+    """Merge adjacent shots toward `target` seconds, for --detail brief."""
+    out: list[tuple[float, float]] = []
+    for start, end in shots:
+        if out and out[-1][1] - out[-1][0] < target:
+            out[-1] = (out[-1][0], end)
+        else:
+            out.append((start, end))
+    return out
+
+
+def _sample_times(start: float, end: float, n: int) -> list[float]:
+    """n frames strictly inside the shot, away from transition frames at the edges."""
+    span = end - start
+    if n <= 1 or span < 1.2:
+        return [start + span * 0.5]
+    step = 0.6 / max(n - 1, 1)
+    return [start + span * (0.2 + step * i) for i in range(n)]
+
+
+def _frame(video: Path, t: float, dest: Path) -> Path | None:
+    """Frame-accurate grab. -ss must follow -i, or ffmpeg snaps to a keyframe."""
+    try:
+        _run(["ffmpeg", "-v", "error", "-i", str(video), "-ss", f"{t:.3f}",
+              "-frames:v", "1", "-vf", f"scale={FRAME_WIDTH}:-1",
+              "-q:v", "3", str(dest), "-y"], timeout=120)
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return dest if dest.exists() and dest.stat().st_size else None
+
+
+def speech_spans(video: Path, min_gap: float = 0.45,
+                 min_len: float = 0.50) -> list[tuple[float, float]]:
+    """Measured speech regions from a 300-3400 Hz RMS envelope.
+
+    Band-limiting keeps scored music from dominating. A window counts as speech when
+    it rises well above the track's own noise floor. Spans under min_len are dropped:
+    on scored footage those are percussion accents, not narration.
+    """
+    try:
+        proc = subprocess.run(
+            ["ffmpeg", "-v", "error", "-i", str(video), "-vn", "-ac", "1", "-ar", "16000",
+             "-af", "highpass=f=300,lowpass=f=3400,asetnsamples=n=1600,"
+                    "astats=metadata=1:reset=1,"
+                    "ametadata=print:key=lavfi.astats.Overall.RMS_level:file=-",
+             "-f", "null", "-"],
+            capture_output=True, text=True, timeout=900)
+    except (subprocess.SubprocessError, OSError):
+        return []
+
+    frames: list[tuple[float, float]] = []
+    t: float | None = None
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("frame:"):
+            m = re.search(r"pts_time:([0-9.]+)", line)
+            t = float(m.group(1)) if m else None
+        elif "RMS_level=" in line and t is not None:
+            try:
+                frames.append((t, float(line.split("=", 1)[1])))
+            except ValueError:
+                pass
+            t = None
+    if len(frames) < 5:
+        return []
+
+    levels = sorted(v for _, v in frames if v > -120)
+    if not levels:
+        return []
+    floor = levels[len(levels) // 5]
+    ceil_ = levels[int(len(levels) * 0.98)]
+    thresh = floor + max(6.0, (ceil_ - floor) * 0.45)
+
+    spans: list[list[float]] = []
+    for ts_, lvl in frames:
+        if lvl < thresh:
+            continue
+        if spans and ts_ - spans[-1][1] <= min_gap:
+            spans[-1][1] = ts_ + 0.1
+        else:
+            spans.append([ts_, ts_ + 0.1])
+    return [(a, b) for a, b in spans if b - a >= min_len]
+
+
+# ---------------------------------------------------------------------- model
+
+class _Endpoint:
+    def __init__(self, base_url: str, model: str):
+        self.url = base_url.rstrip("/") + "/chat/completions"
+        self.model = model
+
+    def _post(self, payload: dict) -> str:
+        req = urllib.request.Request(
+            self.url, data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as r:
+                body = json.load(r)
+        except urllib.error.HTTPError as e:
+            detail = e.read()[:300].decode(errors="replace")
+            raise GenerationError(f"{self.url} returned {e.code}: {detail}") from e
+        except urllib.error.URLError as e:
+            raise GenerationError(
+                f"cannot reach {self.url} ({e.reason}). Is the local server running?"
+            ) from e
+        try:
+            return body["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError) as e:
+            raise GenerationError(f"unexpected response from {self.url}") from e
+
+    def _base(self, max_tokens: int) -> dict:
+        return {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            # Gemma 4's recommended sampling. Near-greedy sampling degrades these
+            # models and can make them skip parts of a prompt outright.
+            "temperature": 1.0, "top_p": 0.95, "top_k": 64,
+            # Some servers default reasoning ON, which spends the whole budget in
+            # reasoning_content and returns empty content. Ignored where unsupported.
+            "chat_template_kwargs": {"enable_thinking": False},
+            "reasoning_budget": 0,
+        }
+
+    def ask(self, prompt: str, images: list[Path] | None = None,
+            max_tokens: int = 1200) -> str:
+        content: list[dict] = [{"type": "text", "text": prompt}]
+        for p in images or []:
+            b64 = base64.b64encode(p.read_bytes()).decode()
+            content.append({"type": "image_url",
+                            "image_url": {"url": f"data:image/jpeg;base64,{b64}"}})
+        return self._post({**self._base(max_tokens),
+                           "messages": [{"role": "user", "content": content}]})
+
+    def ask_audio(self, prompt: str, wav: Path, max_tokens: int = 900) -> str:
+        b64 = base64.b64encode(wav.read_bytes()).decode()
+        return self._post({**self._base(max_tokens), "messages": [{
+            "role": "user", "content": [
+                {"type": "text", "text": prompt},
+                {"type": "input_audio", "input_audio": {"data": b64, "format": "wav"}},
+            ]}]})
+
+
+def _parse_json(raw: str) -> dict:
+    """Lenient JSON extraction: strips fences, tolerates trailing prose."""
+    s = re.sub(r"^\s*```(?:json)?|```\s*$", "", raw.strip(), flags=re.MULTILINE).strip()
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        pass
+    depth, start = 0, None
+    for i, ch in enumerate(s):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start is not None:
+                try:
+                    return json.loads(s[start:i + 1])
+                except json.JSONDecodeError:
+                    start = None
+    raise ValueError("no JSON object in model output")
+
+
+def _salvage(raw: str) -> dict:
+    """Recover a description from JSON cut off mid-object by a token limit.
+
+    A description that ran past max_tokens is still a good description; only the
+    closing brace is missing.
+    """
+    out: dict = {}
+    m = re.search(r'"description"\s*:\s*"((?:[^"\\]|\\.)*)"', raw)
+    partial = False
+    if not m:
+        m = re.search(r'"description"\s*:\s*"((?:[^"\\]|\\.)*)$', raw)
+        partial = bool(m)
+    if not m:
+        return out
+    text = m.group(1)
+    try:
+        text = json.loads(f'"{text}"')
+    except json.JSONDecodeError:
+        pass
+    if partial:
+        cut = max(text.rfind("."), text.rfind("!"), text.rfind("?"))
+        text = text[:cut + 1] if cut > 20 else text.rsplit(" ", 1)[0]
+    if text.strip():
+        out["description"] = text.strip()
+    return out
+
+
+# ------------------------------------------------------------------ transcript
+
+def _transcribe(video: Path, endpoint: _Endpoint) -> list[tuple[float, str]]:
+    """Words from the model's audio encoder, timestamps from measurement.
+
+    Returns [] when no speech is measured -- without asking the model, because a
+    model handed a silent track answers conversationally rather than declining.
+    """
+    spans = speech_spans(video)
+    if not spans:
+        return []
+    with tempfile.TemporaryDirectory() as td:
+        wav = Path(td) / "audio.wav"
+        try:
+            _run(["ffmpeg", "-v", "error", "-i", str(video), "-vn",
+                  "-ac", "1", "-ar", "16000", str(wav), "-y"], timeout=300)
+        except (subprocess.SubprocessError, OSError):
+            return []
+        if not wav.exists():
+            return []
+        try:
+            raw = endpoint.ask_audio(_ASR_PROMPT.format(n=len(spans)), wav)
+        except GenerationError:
+            return []          # no audio encoder, or the endpoint refused the payload
+
+    head = raw.strip().lower()[:200]
+    if not head or any(marker in head for marker in _NON_TRANSCRIPT):
+        return []
+    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+    if len(lines) != len(spans):
+        joined = re.sub(r"\s+", " ", " ".join(lines)).strip()
+        lines = [p.strip() for p in
+                 re.split(r'(?<=[.!?])\s+(?=[A-Z"\'“])', joined) if p.strip()]
+    if not lines:
+        return []
+    if len(lines) == len(spans):
+        return [(spans[i][0], lines[i]) for i in range(len(lines))]
+    # Counts diverged: keep order, place proportionally inside the measured window.
+    start, end = spans[0][0], max(spans[-1][1], spans[0][0] + 0.5)
+    total = sum(len(x) for x in lines) or 1
+    out, acc = [], 0
+    for line in lines:
+        out.append((round(start + (end - start) * acc / total, 1), line))
+        acc += len(line)
+    return out
+
+
+# -------------------------------------------------------------------- assembly
+
+def _ts(seconds: float) -> str:
+    m, s = divmod(seconds, 60)
+    if m >= 60:
+        h, m = divmod(int(m), 60)
+        return f"{h:02d}:{int(m):02d}:{s:04.1f}"
+    return f"{int(m):02d}:{s:04.1f}"
+
+
+DEFAULT_SCENE_THRESHOLD = 0.15
+
+
+def describe_video_local(
+    video: str | Path,
+    *,
+    model: str = DEFAULT_LOCAL_MODEL,
+    detail: str = "standard",
+    base_url: str = DEFAULT_BASE_URL,
+    continuity: bool = True,
+    scene_threshold: float = DEFAULT_SCENE_THRESHOLD,
+    usage_out: dict | None = None,
+) -> str:
+    """Return the CDAF body markdown for `video`, using a local model.
+
+    Same contract as generate.describe_video: the five required sections in order.
+    """
+    if detail not in _DETAIL_FRAMES:
+        raise ValueError(f"detail must be one of {sorted(_DETAIL_FRAMES)}")
+    _require_ffmpeg()
+    video = Path(video)
+    endpoint = _Endpoint(base_url, model)
+
+    duration = _duration(video)
+    shots = build_shots(duration, detect_cuts(video, scene_threshold))
+    if detail == "brief":
+        shots = coarsen(shots)
+
+    per_shot = _DETAIL_FRAMES[detail]
+    sentences = _DETAIL_SENTENCES[detail]
+    described: list[dict] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        for i, (start, end) in enumerate(shots, 1):
+            frames = [f for f in (
+                _frame(video, min(t, duration - 0.05), Path(td) / f"s{i:03d}_{j}.jpg")
+                for j, t in enumerate(_sample_times(start, end, per_shot))) if f]
+            if not frames:
+                described.append({"start": start, "end": end, "description": "",
+                                  "text": [], "failed": True})
+                continue
+
+            parsed = None
+            for budget in (1200, 1800):
+                try:
+                    raw = endpoint.ask(
+                        _SHOT_PROMPT.format(n=len(frames), sentences=sentences),
+                        frames, max_tokens=budget)
+                except GenerationError:
+                    continue
+                try:
+                    parsed = _parse_json(raw)
+                    break
+                except ValueError:
+                    parsed = _salvage(raw) or None
+                    if parsed:
+                        break
+
+            if not parsed:
+                described.append({"start": start, "end": end, "description": "",
+                                  "text": [], "failed": True})
+                continue
+
+            desc = str(parsed.get("description") or "").strip()
+            setting = str(parsed.get("setting") or "").strip()
+            if setting and setting.lower() not in desc.lower():
+                desc = f"{desc} Setting: {setting}."
+            texts = [str(t).strip() for t in (parsed.get("visible_text") or [])
+                     if str(t).strip()]
+            described.append({"start": start, "end": end, "description": desc,
+                              "text": texts, "failed": not desc})
+
+    transcript = _transcribe(video, endpoint)
+    narration = "\n".join(f"[{_ts(t)}] {x}" for t, x in transcript) or "(none)"
+    screen = [(sh["start"], t) for sh in described for t in sh["text"]]
+    screen_text = "\n".join(f"[{_ts(t)}] {x}" for t, x in screen) or "(none)"
+
+    summary, tags = "", []
+    if continuity:
+        shots_in = "\n".join(
+            f"{i + 1}. {s['description'] if not s['failed'] else '(NOT DESCRIBED)'}"
+            for i, s in enumerate(described))
+        try:
+            parsed = _parse_json(endpoint.ask(_CONTINUITY_PROMPT.format(
+                n=len(described), sentences=sentences, shots=shots_in,
+                narration=narration, screen_text=screen_text), max_tokens=3000))
+            segs = parsed.get("segments")
+            if isinstance(segs, list) and len(segs) == len(described):
+                for original, new in zip(described, segs):
+                    if not original["failed"] and str(new).strip():
+                        original["description"] = str(new).strip()
+            summary = str(parsed.get("summary") or "").strip()
+            tags = [str(t).strip() for t in (parsed.get("tags") or []) if str(t).strip()]
+        except (GenerationError, ValueError) as e:
+            print(f"cdaf: continuity pass skipped ({e})", file=sys.stderr)
+
+    if not any(not s["failed"] for s in described):
+        raise GenerationError(
+            f"the local model described none of {video.name}'s {len(shots)} shots"
+        )
+
+    lines = ["## Summary", summary or "(unavailable)", "", "## Segments"]
+    for sh in described:
+        lines.append(f"[{_ts(sh['start'])}-{_ts(sh['end'])}] "
+                     f"{sh['description'] or '(not described)'}")
+    lines += ["", "## Transcript"]
+    lines += [f"[{_ts(t)}] {x}" for t, x in transcript] or ["(no speech)"]
+    lines += ["", "## On-screen Text"]
+    lines += [f'[{_ts(t)}] "{x}"' for t, x in screen] or ["(none)"]
+    lines += ["", "## Tags", ", ".join(tags) if tags else "(none)"]
+
+    if usage_out is not None:
+        usage_out.update({"shots": len(shots), "model_calls":
+                          len(shots) + (1 if continuity else 0) + (1 if transcript else 0)})
+    return "\n".join(lines)
+
+
+def local_header_extras(continuity: bool, transcribed: bool,
+                        threshold: float = DEFAULT_SCENE_THRESHOLD) -> dict[str, str]:
+    """`x-` keys recording how this body was produced.
+
+    SPEC.md reserves the `x-` prefix for producers. A consumer deciding whether to
+    trust a timestamp benefits from knowing whether it was measured or inferred.
+    """
+    return {
+        "x-shot-source": f"ffmpeg-scene-detect@{threshold:g}",
+        "x-shot-isolation": "per-shot",
+        "x-continuity-pass": "yes" if continuity else "no",
+        "x-transcript-timing": "measured-rms" if transcribed else "none",
+    }

--- a/cli/tests/test_local.py
+++ b/cli/tests/test_local.py
@@ -1,0 +1,134 @@
+"""Unit tests for the local provider. No network, no ffmpeg, no model."""
+
+import pytest
+
+from cdaf import local
+from cdaf.generate import PROVIDERS, generate_sidecar
+
+
+# ------------------------------------------------------------------- shots
+
+def test_build_shots_splits_on_cuts():
+    assert local.build_shots(12.0, [3.0, 6.0, 9.0]) == [
+        (0.0, 3.0), (3.0, 6.0), (6.0, 9.0), (9.0, 12.0)
+    ]
+
+
+def test_build_shots_no_cuts_is_one_shot():
+    assert local.build_shots(4.0, []) == [(0.0, 4.0)]
+
+
+def test_build_shots_absorbs_slivers():
+    # A cut 0.1s before the end must not produce a 0.1s segment.
+    shots = local.build_shots(10.0, [5.0, 9.95])
+    assert shots == [(0.0, 5.0), (5.0, 10.0)]
+
+
+def test_build_shots_is_contiguous_and_covers_duration():
+    shots = local.build_shots(20.0, [1.0, 4.5, 11.0, 19.0])
+    assert shots[0][0] == 0.0
+    assert shots[-1][1] == 20.0
+    for (_, end), (start, _) in zip(shots, shots[1:]):
+        assert end == start
+
+
+def test_coarsen_merges_toward_target():
+    fine = [(0.0, 1.0), (1.0, 2.0), (2.0, 3.0), (3.0, 12.0)]
+    coarse = local.coarsen(fine, target=8.0)
+    assert coarse[0][0] == 0.0
+    assert coarse[-1][1] == 12.0
+    assert len(coarse) < len(fine)
+
+
+def test_sample_times_stay_inside_the_shot():
+    for n in (1, 2, 3):
+        for t in local._sample_times(10.0, 14.0, n):
+            assert 10.0 < t < 14.0
+
+
+# ------------------------------------------------------------- json recovery
+
+def test_parse_json_tolerates_code_fences():
+    assert local._parse_json('```json\n{"description": "ok"}\n```')["description"] == "ok"
+
+
+def test_parse_json_tolerates_trailing_prose():
+    assert local._parse_json('{"description": "ok"} Hope that helps!')["description"] == "ok"
+
+
+def test_parse_json_raises_without_an_object():
+    with pytest.raises(ValueError):
+        local._parse_json("no json here")
+
+
+def test_salvage_recovers_a_truncated_description():
+    """A description cut off by max_tokens is still usable; only the brace is missing."""
+    truncated = '{"description": "A hand opens a drawer of tools. In the second frame it is'
+    assert local._salvage(truncated)["description"] == "A hand opens a drawer of tools."
+
+
+def test_salvage_returns_empty_when_there_is_nothing_to_recover():
+    assert local._salvage('{"setting": "kitchen"}') == {}
+
+
+# ------------------------------------------------------- transcript guard
+
+@pytest.mark.parametrize("reply", [
+    "I am a large language model, trained by Google.",
+    "There is no speech in this audio.",
+    "I cannot transcribe this file.",
+    "Sorry, the audio appears to be silent.",
+])
+def test_non_transcript_replies_are_recognised(reply):
+    """Handed a silent track, a model answers as a chatbot rather than declining.
+
+    Such a reply must never reach the sidecar looking like narration.
+    """
+    head = reply.strip().lower()[:200]
+    assert any(marker in head for marker in local._NON_TRANSCRIPT)
+
+
+def test_real_narration_is_not_mistaken_for_a_refusal():
+    line = "Funny how the things you put off always seem bigger than they are."
+    head = line.strip().lower()[:200]
+    assert not any(marker in head for marker in local._NON_TRANSCRIPT)
+
+
+# ------------------------------------------------------------ header extras
+
+def test_header_extras_record_provenance():
+    extras = local.local_header_extras(continuity=True, transcribed=True, threshold=0.15)
+    assert extras["x-shot-source"] == "ffmpeg-scene-detect@0.15"
+    assert extras["x-transcript-timing"] == "measured-rms"
+
+
+def test_header_extras_mark_an_untranscribed_clip():
+    extras = local.local_header_extras(continuity=False, transcribed=False)
+    assert extras["x-transcript-timing"] == "none"
+    assert extras["x-continuity-pass"] == "no"
+
+
+def test_header_extras_use_only_reserved_x_keys():
+    """SPEC.md reserves the `x-` prefix for producer extensions."""
+    assert all(k.startswith("x-") for k in
+               local.local_header_extras(continuity=True, transcribed=True))
+
+
+# ---------------------------------------------------------------- provider
+
+def test_providers_are_gemini_and_local():
+    assert PROVIDERS == ("gemini", "local")
+
+
+def test_unknown_provider_is_rejected(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+    with pytest.raises(ValueError, match="provider must be one of"):
+        generate_sidecar(video, provider="nope")
+
+
+def test_detail_must_be_known(tmp_path):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"not really a video")
+    with pytest.raises(ValueError, match="detail must be one of"):
+        local.describe_video_local(video, detail="exhaustive")

--- a/skills/claude-code/cdaf/SKILL.md
+++ b/skills/claude-code/cdaf/SKILL.md
@@ -55,14 +55,28 @@ Format: a `key: value` header between `--- CDAF/1.0` and `---`, then markdown:
 
 ## Generating sidecars
 
-Needs Python ≥ 3.10 and a Gemini API key in `GEMINI_API_KEY`
-(free tier: https://aistudio.google.com/apikey). Install the CLI once:
+Two providers. Both write the same v1.0 format and either output passes `cdaf validate`.
+
+### Local model — no API key, no cost, footage stays on the machine
 
 ```bash
-pip install "cdaf[generate] @ git+https://github.com/UditAkhourii/cdaf.git#subdirectory=cli"
+cdaf generate <video> --local          # or --provider local
 ```
 
-Then:
+Needs `ffmpeg` and an OpenAI-compatible endpoint serving a model with a vision encoder
+(default `http://127.0.0.1:8090/v1`, override with `--base-url` / `--model`, or the
+`CDAF_BASE_URL` / `CDAF_LOCAL_MODEL` env vars). An audio encoder, where the model has
+one, is used for the transcript. Check the endpoint is up before offering this route:
+
+```bash
+curl -s localhost:8090/props   # llama-server: reports which modalities are loaded
+```
+
+Slower per clip than the API, but free and private, and cost scales per **shot** rather
+than per second of footage — so long clips are far cheaper here. Set `CDAF_PROVIDER=local`
+to make it the default.
+
+### Gemini API
 
 ```bash
 cdaf generate <video-or-directory>      # skips sidecars that are already fresh
@@ -70,9 +84,38 @@ cdaf generate <video> --force           # regenerate even if fresh
 cdaf generate ./footage --detail rich   # brief | standard | rich
 ```
 
-Generation calls a paid API and takes ~10s per clip. **Ask the user before batch-
-generating a large library**, and tell them roughly how many videos you are about to
-process.
+Needs Python >= 3.10 and `GEMINI_API_KEY`
+(free tier: https://aistudio.google.com/apikey). Install the CLI once:
+
+```bash
+pip install "cdaf[generate] @ git+https://github.com/UditAkhourii/cdaf.git#subdirectory=cli"
+```
+
+Faster per clip and handles whole directories, but calls a paid API. **Ask the user
+before batch-generating a large library**, and tell them roughly how many videos you are
+about to process.
+
+## Reading a sidecar critically
+
+A sidecar is generated text, not ground truth. Header `x-` keys, when present, tell you
+how much to trust which parts:
+
+- `x-shot-isolation: per-shot` — each segment was described without sight of the others,
+  which suppresses invented continuity between shots. Absent this, be sceptical of any
+  claim that a task was **completed**: a generator seeing the whole video at once will
+  narrate the expected outcome even when the footage withholds it, and the fabricated
+  line is indistinguishable from a correct one.
+- `x-shot-source: ffmpeg-scene-detect@<threshold>` — boundaries came from the container
+  and are frame-exact. Absent this, treat segment timestamps as approximate; a
+  model-inferred boundary can drift by a second or more.
+- `x-transcript-timing: measured-rms` — transcript times were measured from audio.
+  `none` means there was no measurable speech. Absent the key entirely, assume the model
+  guessed the times, which it does poorly even when the words are verbatim.
+
+Two things no generator records reliably: the **mark-up state** of on-screen text
+(whether list items are crossed out, checked, or highlighted), and **incidental
+background text** on packaging or labels, which has produced confident phantom brand
+names. If either carries the meaning of a shot, look at the frames.
 
 ## Working across a footage library
 


### PR DESCRIPTION
Adds a second generation provider so `cdaf generate` can use a local multimodal model
instead of the Gemini Files API. Gemini stays the default — existing behaviour and
existing sidecars are unchanged.

```bash
cdaf generate ./clip.mp4 --local          # or --provider local
CDAF_PROVIDER=local cdaf generate ./clip.mp4
```

No API key, no per-clip cost, and the footage never leaves the machine. **No new
dependencies** — stdlib `urllib` only. `ffmpeg` is required at runtime and checked for
explicitly.

### Why it isn't just a swapped endpoint

The Files API path (upload the whole video, ask once) has no local equivalent, so the
provider samples frames itself. That forced three design choices which turned out to be
interesting on their own merits:

**Boundaries come from the container, not the model.** ffmpeg scene detection puts
segment boundaries on real cuts. On a synthetic 12s clip with cuts authored at exactly
3.0 / 6.0 / 9.0:

| `--scene-threshold` | detected |
|---|---|
| 0.20 | 3.0 |
| 0.15 (default) | 3.0, 6.0 |
| 0.06 | **3.0, 6.0, 9.0 — frame-exact** |

Precision is perfect; **recall is threshold-dependent**, which is why it's a flag rather
than a constant. A low-contrast transition can score below threshold and merge two shots.

**Each shot is described without sight of the others.** A describer that cannot see the
next shot cannot invent a causal chain across shots. This measurably suppresses a failure
mode I hit repeatedly with whole-video context: fluent, specific narration of an event the
footage deliberately withholds. More on that in the issue I'm filing separately.

**Transcript words from the model, timing from measurement.** The model transcribes
verbatim but times poorly — in my runs it snapped to round numbers, uniformly early
against measured onsets. So timing comes from a 300–3400 Hz RMS envelope instead.

One safety consequence worth calling out: when no speech is measured, the provider does
**not** ask the model. Handed a silent track, a model doesn't decline — it answers
conversationally, and `"I am a large language model, trained by Google."` lands in the
Transcript section looking like narration. Measured silence short-circuits ASR, and a
guard rejects replies that read as the assistant talking rather than transcribing.

### Provenance in the header

Four `x-` keys (the prefix SPEC.md reserves for producers) so a consumer can tell
measured values from inferred ones:

```
x-shot-source: ffmpeg-scene-detect@0.06
x-shot-isolation: per-shot
x-continuity-pass: yes
x-transcript-timing: measured-rms
```

`SKILL.md` gains a section teaching agents to read those keys — and to distrust
completion claims and timestamps when they're absent.

### Output

Same five-section body contract, validated by the existing CLI. From the synthetic clip
above:

```
## Segments
[00:00.0-00:03.0] The word 'ALPHA' is displayed in a white, stylized font against a solid blue background.
[00:03.0-00:06.0] Next, 'BRAVO' appears in a bold, white, rounded font against a solid red background.
[00:06.0-00:09.0] Then, 'CHARLIE' is shown in white, stylized capital letters centered on a solid green background.
[00:09.0-00:12.0] Finally, 'DELTA' is displayed in a white, stylized, slightly distorted font against a solid purple background.

## Transcript
(no speech)
```

Boundaries exact, all four labels read, silence correctly reported.

### Tradeoffs, honestly

- **Slower per clip.** Sequential per-shot calls plus local inference. Cost scales per
  **shot** rather than per second, so long footage is relatively cheaper here — but a
  short clip is faster via the API.
- **One clip at a time.** No directory mode; the Gemini path keeps that.
- **A continuity pass** runs after the isolated descriptions to restore pronouns and name
  objects that neighbouring shots make unambiguous — otherwise the subject is
  reintroduced from scratch every shot. It sees only text, never pixels, and is forbidden
  from adding actions or completions. Disable by passing `continuity=False` to
  `describe_video_local` if you'd rather ship the strictly literal output; happy to expose
  it as a CLI flag if you want it.
- Reference target was Gemma 4 12B (its GGUF carries a combined vision+audio projector),
  but nothing is model-specific beyond the sampling defaults.

### Testing

`32 passed` — the 10 existing tests plus 22 new ones covering shot construction,
truncated-JSON recovery, the non-transcript guard, header provenance, and provider
validation. All offline: no network, no ffmpeg, no model.

Also fixes `cli/README.md`, which still carried the `pip install cdaf[generate]` form
that 404s (the root README was fixed in 61dcde3; this one was missed).

Happy to split this, rename the flags, or drop the continuity pass — whatever fits how
you'd rather see providers organised.
